### PR TITLE
Update centos8_installation.md

### DIFF
--- a/docs/openvk_engine/centos8_installation.md
+++ b/docs/openvk_engine/centos8_installation.md
@@ -94,7 +94,7 @@ dnf -y install --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-fr
 🖥Then install SDL2 and ffmpeg:
 
 ```bash
-dnf -y install http://rpmfind.net/linux/epel/7/x86_64/Packages/s/SDL2-2.0.10-1.el7.x86_64.rpm
+dnf -y install https://rpmfind.net/linux/epel/7/x86_64/Packages/s/SDL2-2.0.14-2.el7.x86_64.rpm
 dnf -y install ffmpeg
 ```
 


### PR DESCRIPTION
Обновил актуальную ссылку на SDL2 пакет.

Fix Status code: 404 for http://rpmfind.net/linux/epel/7/x86_64/Packages/s/SDL2-2.0.10-1.el7.x86_64.rpm (IP: 195.220.108.108)

Ссылка на репозиторий:
https://rpmfind.net/linux/epel/7/x86_64/Packages/s/

Ссылка на актуальный пакет:
https://rpmfind.net/linux/epel/7/x86_64/Packages/s/SDL2-2.0.14-2.el7.x86_64.rpm