### PR TITLE
fix type fields in user.md

### DIFF
--- a/docs/openvk_engine/api/objects/user.md
+++ b/docs/openvk_engine/api/objects/user.md
@@ -26,10 +26,21 @@
 |`telegram`|string|Users telegram|
 |`about`|string|Users description|
 |`rating`|int|Users rating|
-|`correct_counters`|array|Array with user's counters|
-|`background`|array|Background photo urls|
+|`correct_counters`|UserCounters object|Array with user's counters|
+|`background`|array[string]|Background photo urls|
 |`reg_date`|int|User registration date|
 |`is_dead`|bool|Is user dead|
 |`nickname`|string|Nickname, or "middle name"|
 |`blacklisted_by_me`|bool|Is blacklisted by current user|
 |`blacklisted`|bool|Is this user blacklisted me|
+
+## UserCounters
+| Property | Value | Description |
+|---|---|---|
+|`friends`|int||
+|`photos`|int||
+|`videos`|int||
+|`audios`|int||
+|`notes`|int||
+|`groups`|int||
+|`online_friends`|int||

--- a/docs/openvk_engine/api/objects/user.md
+++ b/docs/openvk_engine/api/objects/user.md
@@ -25,7 +25,7 @@
 |`email`|string|Users contact email|
 |`telegram`|string|Users telegram|
 |`about`|string|Users description|
-|`rating`|string|Users rating|
+|`rating`|int|Users rating|
 |`correct_counters`|array|Array with user's counters|
 |`background`|array|Background photo urls|
 |`reg_date`|int|User registration date|


### PR DESCRIPTION
Какая бибизяна на поле с рейтингом в документации поставила string, если там всегда число?

```json
{"response":[{"id":34172,"first_name":"Константин","last_name":"Антипов","is_closed":false,"can_access_closed":true,"rating":5000,"online":0}]}
```